### PR TITLE
CSCvh99543: update to 6-digit / version.sh scheme

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -35,11 +35,13 @@ AM_CFLAGS = -g -Wall -Wextra -D_GNU_SOURCE
 # depcomp is listed as a workaround for a bug in automake:
 # http://debbugs.gnu.org/cgi/bugreport.cgi?bug=14594
 EXTRA_DIST = \
-	VERSION \
+	version.sh \
+	UPSTREAM_VERSION \
 	COPYING \
 	README.md \
 	libusnic_verbs.spec.in \
 	usnic.driver \
+        config/find_distro.pl \
 	config/depcomp
 
 usnicconfdir = $(sysconfdir)/libibverbs.d

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Tarballs are available for download from https://github.com/cisco/libusnic_verbs
 
 -----
 
-The intent for this package is  to install the usnic libibverbs plugin
+The intent for this package is to install the usnic libibverbs plugin
 in the same location as all other libibverbs plugins, and also install
-the `usnic.driver`  meta data text  file in  the same location  as all
+the `usnic.driver` meta data text file in the same location as all
 ther other libibverbs meta data text files.
 
 For example, here's the correct `configure` line to build this package

--- a/UPSTREAM_VERSION
+++ b/UPSTREAM_VERSION
@@ -1,0 +1,2 @@
+# Git hash/tag to check out from upstream libfabric git repo
+GIT_ID=HEAD

--- a/VERSION
+++ b/VERSION
@@ -1,5 +1,0 @@
-# Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
-
-# If set, use this specific Git ID for the release package.
-# A few commits beyond 2.0.2, with some Cisco releng fixes
-GIT_ID=v2.0.3

--- a/config/find_distro.pl
+++ b/config/find_distro.pl
@@ -1,0 +1,55 @@
+#!/usr/bin/env perl
+
+sub find_distro {
+    my $distro;
+    my $rhel_rel_path = "/etc/redhat-release";
+    my $sles_rel_path = "/etc/SuSE-release";
+    my $lsb_rel_path = "/etc/lsb-release";
+
+    # RHEL 6, 7
+    if (-r $rhel_rel_path) {
+        $distro = `cat $rhel_rel_path | cut -d " " -f 7 | sed "s/^/rhel/" | sed "s/\\\./u/"`;
+    }
+
+    # SLES 12
+    elsif (-r $sles_rel_path) {
+        my $ver = `cat $sles_rel_path | grep "^VERSION" | tr -d " " | cut -d "=" -f 2`;
+        chomp($ver);
+        my $patchlevel = `cat $sles_rel_path | grep "^PATCHLEVEL" | tr -d " " | cut -d "=" -f 2`;
+        $distro = "sles${ver}sp${patchlevel}";
+    }
+
+    # Ubuntu 14, 16 LTS
+    elsif (-r $lsb_rel_path) {
+        open(IN, $lsb_rel_path) ||
+            die "Can't open $lsb_rel_path";
+        my $lsb_fields;
+        while (<IN>) {
+            chomp;
+            my ($field, $value) = split('=', $_);
+            $lsb_fields->{$field} = $value;
+        }
+        close(IN);
+
+        if ($lsb_fields->{'DISTRIB_ID'} eq "Ubuntu" &&
+            $lsb_fields->{'DISTRIB_RELEASE'} eq "14.04") {
+            $distro = "ubuntu1404lts";
+        } elsif ($lsb_fields->{'DISTRIB_ID'} eq "Ubuntu" &&
+            $lsb_fields->{'DISTRIB_RELEASE'} eq "16.04") {
+            $distro = "ubuntu1604lts";
+        } else {
+            die "*** Unknown Linux distro: $lsb_fields->{'DISTRIB_ID'} / $lsb_fields->{'DISTRIB_RELEASE'}";
+        }
+    }
+
+    # Shrug
+    else {
+        die "*** Unknown Linux distro -- aborting build";
+    }
+
+    chomp($distro);
+    return $distro;
+}
+
+print(find_distro() . "\n");
+exit(0);

--- a/configure.ac
+++ b/configure.ac
@@ -28,20 +28,27 @@
 
 dnl Note that the version number in the line below will be edited
 dnl by the releng-scripts.
-m4_define(libusnic_verbs_version, [2.0.3])
+m4_define(libusnic_verbs_version,
+          m4_normalize(esyscmd([./version.sh --version])))
 
 AC_PREREQ(2.57)
-AC_INIT([libusnic_verbs], libusnic_verbs_version, [http://cisco.com/])
+AC_INIT([libusnic_verbs], libusnic_verbs_version, [https://cisco.com/])
 AC_CONFIG_SRCDIR([src/empty_usnic.c])
 AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_HEADER(config.h)
 
-AM_INIT_AUTOMAKE([-Wall foreign no-define 1.11 subdir-objects dist-bzip2])
+AM_INIT_AUTOMAKE([-Wall foreign no-define 1.11 subdir-objects no-dist-gzip dist-bzip2])
 
 AC_CONFIG_MACRO_DIR([config])
 
-LIBUSNIC_VERBS_VERSION="libusnic_verbs_version"
-AC_SUBST(LIBUSNIC_VERBS_VERSION)
+# Get the distro name
+DISTRO=`perl $srcdir/config/find_distro.pl`
+LIBUSNIC_VERBS_SRC_VERSION="libusnic_verbs_version"
+LIBUSNIC_VERBS_PKG_VERSION="$LIBUSNIC_VERBS_SRC_VERSION.$DISTRO"
+LIBUSNIC_VERBS_PKG_RELEASE=`$srcdir/version.sh --build-id`
+AC_SUBST(LIBUSNIC_VERBS_SRC_VERSION)
+AC_SUBST(LIBUSNIC_VERBS_PKG_VERSION)
+AC_SUBST(LIBUSNIC_VERBS_PKG_RELEASE)
 
 dnl SILENT_RULES is new in AM 1.11, but we require 1.11 or higher via
 dnl autogen.  Limited testing shows that calling SILENT_RULES directly

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-libusnic-verbs (@LIBUSNIC_VERBS_VERSION@) unstable; urgency=low
+libusnic-verbs (@LIBUSNIC_VERBS_PKG_VERSION@) unstable; urgency=low
 
   * Cisco dummy libusnic_verbs to prevent libibverbs from complaining about a missing userspace driver
 

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Maintainer: @CISCO_MAINTAINER@ <@CISCO_MAINTAINER_EMAIL@>
 Build-Depends: debhelper (>= 9.0.0), autotools-dev, libibverbs-dev, make, quilt, dpkg-dev
 Standards-Version: 3.9.5
 Section: libs
-Homepage: http://cisco.com/
+Homepage: https://cisco.com/
 
 Package: libusnic-verbs
 Section: libs

--- a/debian/rules
+++ b/debian/rules
@@ -1,12 +1,19 @@
 #!/usr/bin/make -f
 # -*- makefile -*-
 
+PACKAGE=libusnic-verbs
+DEST_DIR=$(CURDIR)/debian/$(PACKAGE)
+LIBUSNIC_VERBS_PKG_VERSION=@LIBUSNIC_VERBS_PKG_VERSION@
+
 # Make things verbose so that we can see what's going on
 export DH_VERBOSE=1
 export DH_OPTIONS=-v
 
 %:
 	dh $@  --with autotools-dev --parallel
+
+override_dh_gencontrol:
+	dh_gencontrol -- -v$(LIBUSNIC_VERBS_PKG_VERSION)
 
 # Add in our own configure arugments
 override_dh_auto_configure:

--- a/libusnic_verbs.spec.in
+++ b/libusnic_verbs.spec.in
@@ -28,16 +28,16 @@
 
 Name: libusnic_verbs
 
-Version: @LIBUSNIC_VERBS_VERSION@
-Release: 1
+Version: @LIBUSNIC_VERBS_PKG_VERSION@
+Release: @LIBUSNIC_VERBS_PKG_RELEASE@
 Vendor: Cisco Systems, Inc.
 
 Summary: No-op libibverbs driver for the Cisco usNIC device (you should use libfabric instead)
 
 Group: System Environment/Libraries
 License: GPLv2 or BSD
-Url: http://cisco.com/
-Source: libusnic_verbs-%{version}.tar.bz2
+Url: https://cisco.com/
+Source: libusnic_verbs-@LIBUSNIC_VERBS_SRC_VERSION@.tar.bz2
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}=%{release}-XXXXXX)
 
 BuildRequires: libibverbs-devel >= 1.1.5
@@ -55,7 +55,7 @@ devices.  The Libfabric API is provided for accessing Cisco usNIC
 functionality (see http://libfabric.org/).
 
 %prep
-%setup -q -n %{name}-%{version}
+%setup -q -n %{name}-@LIBUSNIC_VERBS_SRC_VERSION@
 
 %build
 %configure

--- a/releng-deb
+++ b/releng-deb
@@ -40,28 +40,34 @@ sub modify_file_contents {
 Cisco::libusnic_verbs_noop::sanity_check();
 
 my $data = Cisco::libusnic_verbs_noop::parse_argv();
-my $build_arg = $data->{build_arg};
 my $cisco_maintainer = $data->{maintainer};
 my $cisco_maintainer_email = $data->{maintainer_email};
 
 my $start_dir = getcwd();
 
-Cisco::libusnic_verbs_noop::update_git();
+# Values from files
+my $git_id = Cisco::libusnic_verbs_noop::read_upstream_version("UPSTREAM_VERSION");
+my ($src_version, $cisco_build_id) =
+    Cisco::libusnic_verbs_noop::read_cisco_version("version.sh");
+my $distro = Cisco::usnic_releng_common::find_distro();
 
-my $version =
-    Cisco::libusnic_verbs_noop::update_configure_version($build_arg);
+Cisco::libusnic_verbs_noop::update_git($git_id);
 
 my $prefix = "/";
 my $configure_args =
     " --libdir=/usr/lib" .
     " --libexecdir=/usr/lib";
+my $pkg_version = "$src_version-$cisco_build_id.$distro";
+my $pkg_release = $cisco_build_id;
 
-Cisco::libusnic_verbs_noop::modify_file_contents_setup($version,
+Cisco::libusnic_verbs_noop::modify_file_contents_setup($src_version,
+						       $pkg_version,
+						       $pkg_release,
                                                        $cisco_maintainer,
                                                        $cisco_maintainer_email,
                                                        $configure_args);
 
-Cisco::libusnic_verbs_noop::make_tarball($version);
+Cisco::libusnic_verbs_noop::make_tarball($src_version);
 
 #--------------------------------------------------------------------------
 
@@ -75,17 +81,17 @@ Cisco::usnic_releng_common::apply_local_patches("patches");
 print "=== Setting up expected Debian directory structure...\n";
 do_command("rm -rf debian-build");
 mkdir("debian-build");
-do_command("cp libusnic_verbs-$version.tar.bz2 debian-build/libusnic-verbs_$version.orig.tar.bz2");
+do_command("cp libusnic_verbs-$src_version.tar.bz2 debian-build/libusnic-verbs_$src_version.orig.tar.bz2");
 chdir("debian-build");
 
 my $debian_buildtop = getcwd();
 
 # Expand the tarball, and copy the debian directory to the top-level
 # expanded tarball dir, per Debian requirements.
-do_command("tar xf libusnic-verbs_$version.orig.tar.bz2");
-do_command("mv libusnic_verbs-$version libusnic-verbs-$version-1");
+do_command("tar xf libusnic-verbs_$src_version.orig.tar.bz2");
+do_command("mv libusnic_verbs-$src_version libusnic-verbs-$src_version-1");
 my $src_dir = "..";
-my $dest_dir = "libusnic-verbs-$version-1";
+my $dest_dir = "libusnic-verbs-$src_version-1";
 do_command("cp -rp $src_dir/debian $dest_dir");
 
 # Replace @TOKENS@ in some of the debian/ files
@@ -98,11 +104,11 @@ foreach my $file (qw/control changelog rules/) {
 
 # Make the debian source package
 print "=== Building deb source package\n";
-do_command("dpkg-source -b libusnic-verbs-$version-1");
+do_command("dpkg-source -b libusnic-verbs-$src_version-1");
 
 # Build the debian binary package
 print "=== Building deb binary package\n";
-chdir("libusnic-verbs-$version-1");
+chdir("libusnic-verbs-$src_version-1");
 do_command("dpkg-buildpackage -us -uc -j32");
 
 #------------------------------------------------------------------------
@@ -111,7 +117,7 @@ do_command("dpkg-buildpackage -us -uc -j32");
 print "=== Success\n";
 print "  = Files in $debian_buildtop:\n";
 chdir($debian_buildtop);
-system("ls -1 libusnic-verbs_$version*");
+system("ls -1 libusnic-verbs_$src_version*");
 
 # All done
 exit(0);

--- a/releng-rpm
+++ b/releng-rpm
@@ -32,16 +32,19 @@ sub do_command {
 Cisco::libusnic_verbs_noop::sanity_check();
 
 my $data = Cisco::libusnic_verbs_noop::parse_argv();
-my $build_arg = $data->{build_arg};
 
 my $start_dir = getcwd();
 
-Cisco::libusnic_verbs_noop::update_git();
+# Values from files
+my $git_id = Cisco::libusnic_verbs_noop::read_upstream_version("UPSTREAM_VERSION");
+my ($cisco_version, $cisco_build_id) =
+    Cisco::libusnic_verbs_noop::read_cisco_version("version.sh");
+my $distro = Cisco::usnic_releng_common::find_distro();
 
-my $version =
-    Cisco::libusnic_verbs_noop::update_configure_version($build_arg);
+Cisco::libusnic_verbs_noop::update_git($git_id);
 
-Cisco::libusnic_verbs_noop::make_tarball($version, "libusnic_verbs.spec.in");
+Cisco::libusnic_verbs_noop::make_tarball($cisco_version,
+                                         "libusnic_verbs.spec.in");
 
 #--------------------------------------------------------------------------
 
@@ -78,7 +81,7 @@ mkdir("$rpmbuilddir/SPECS");
 mkdir("$rpmbuilddir/SRPMS");
 
 # Copy the files to the right places
-do_command("cp libusnic_verbs-$version.tar.bz2 $rpmbuilddir/SOURCES");
+do_command("cp libusnic_verbs-$cisco_version.tar.bz2 $rpmbuilddir/SOURCES");
 do_command("cp libusnic_verbs.spec $rpmbuilddir/SPECS/libusnic_verbs.spec");
 
 #------------------------------------------------------------------------
@@ -111,17 +114,17 @@ print "=== Success:\n";
 my $tardir = $start_dir;
 print "  = Tarballs in $tardir:\n";
 chdir($tardir);
-system("ls -1 libusnic_verbs*$version*");
+system("ls -1 libusnic_verbs*$cisco_version*");
 
 my $srpmdir = "$rpmbuilddir/SRPMS";
 print "  = SRPM in $srpmdir:\n";
 chdir($srpmdir);
-system("ls -1 libusnic_verbs-$version-*.src.rpm");
+system("ls -1 libusnic_verbs-$cisco_version*.src.rpm");
 
 my $rpmdir = "$rpmbuilddir/RPMS/x86_64";
 print "  = RPMs in $rpmdir:\n";
 chdir($rpmdir);
-system("ls -1 libusnic_verbs*$version-*.rpm");
+system("ls -1 libusnic_verbs*$cisco_version*.rpm");
 
 # All done
 exit(0);

--- a/version.sh
+++ b/version.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Full version has format A.B.C.D-E.F, where A and B are major and
+# minor version numbers respectively and can be modified in this file.
+# Values C through F are all sentinel value 'git' that are overwritten
+# by releng when generating an official build.
+
+option="$1"
+
+# edit major/minor version here
+VERSION_MAJOR_MINOR=3.0
+
+# edited by releng
+VERSION="$VERSION_MAJOR_MINOR.0.0"
+BUILD_ID="4.5"
+
+FULL_VERSION="$VERSION-$BUILD_ID"
+
+case "$option" in
+	--full)
+		echo $FULL_VERSION
+		;;
+	--version)
+		echo $VERSION
+		;;
+	--build-id)
+		echo $BUILD_ID
+		;;
+	*)
+		echo "Usage: $0 {--full|version|build-id}"
+		exit 1
+esac


### PR DESCRIPTION
Output files are now of the form:

* libusnic_verbs-a.b.c.d.tar.bz2
* libusnic_verbs-a.b.c.d.distro-e.f.src.rpm
* libusnic_verbs-a.b.c.d.distro-e.f.arch.rpm
* libusnic_verbs_a.b.c.d-e.f.distro_arch.changes
* libusnic_verbs_a.b.c.d-e.f.distro_arch.deb
* libusnic_verbs_a.b.c.d-e.f.distro.debian.tar.xz
* libusnic_verbs_a.b.c.d-e.f.distro.dsc

There is only a .bz2 tarball created now.  Also, there is no more
--build argument to the releng-* scripts -- the E.F build number is
assumed to be provided from version.sh, which will be [over]written
when releng does a build.

Releng wants to have *all* the digits (A-F) of the version number, so
there will likely be a follow-on commit to replace all of the
git-committed version.sh with A through F set to 0.  The current
values in version.sh reflect what releng's initial A and B values
should be.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>